### PR TITLE
Fix cinema_video_request, thanks to @mikenon

### DIFF
--- a/cinema/gamemode/modules/theater/sh_init.lua
+++ b/cinema/gamemode/modules/theater/sh_init.lua
@@ -141,13 +141,13 @@ local function GetURLInfo( url, Theater )
 		end
 
 	end
-	
+
 	-- Check for valid URL request
 	local URLService = Services["url"]
 	if URLService then
 		info = ServiceMatch( Theater, URLService, data )
 		if istable(info) then
-			info.Type = service:GetClass()
+			info.Type = URLService:GetClass()
 			return info
 		end
 	end


### PR DESCRIPTION
This fixes being unable to use the cinema_video_request "url" command, and "ERROR: gamemodes/cinema/gamemode/modules/theater/sh_init.lua:150: attempt to index global 'service' (a nil value)" as received in the console.
