### PR TITLE
Fixed Twitch.TV Stream service no thumbnail issue (SetDTString Error)

### DIFF
--- a/cinema/gamemode/modules/theater/services/sh_twitch.lua
+++ b/cinema/gamemode/modules/theater/services/sh_twitch.lua
@@ -130,7 +130,7 @@ function SERVICE:GetVideoInfo( data, onSuccess, onFailure )
 		response = response.stream
 
 		local info = {}
-		info.thumbnail = response.preview
+		info.thumbnail = response.preview.medium
 
 		-- Setup title according to the available data
 		if response.channel and response.channel.status then


### PR DESCRIPTION
Requesting Streams via the Twitch.TV Stream Service used to fail because it could not get a Video Thumbnail, resulting in a SetDTString Error.
