### PR TITLE
Fixed issue where Video would be skipped unintentionally

### DIFF
--- a/cinema/gamemode/modules/theater/sh_theater.lua
+++ b/cinema/gamemode/modules/theater/sh_theater.lua
@@ -695,7 +695,12 @@ if SERVER then
 
 		-- Remove player from list
 		table.RemoveByValue(self.Players, ply)
-
+		
+		-- Remove player from vote skip table if they have voted
+		if self:HasPlayerVotedToSkip( ply ) then
+			table.RemoveByValue(self._SkipVotes, ply)
+		end
+		
 		-- Notify player of leaving the theater
 		net.Start("PlayerLeaveTheater")
 		net.Send(ply)


### PR DESCRIPTION
Scenario: Only 1 player in a Theater Room, watching a video. Another player enters the room and Votes to Skip the video.

Issue: When the 2nd player leaves the Room, CheckVoteSkip() is called, and the Video is skipped regardless of the first player's intentions.
