### PR TITLE
Update sh_youtube.lua

### DIFF
--- a/cinema/gamemode/modules/theater/services/sh_youtube.lua
+++ b/cinema/gamemode/modules/theater/services/sh_youtube.lua
@@ -12,7 +12,7 @@ function SERVICE:GetURLInfo( url )
 	local info = {}
 
 	-- http://www.youtube.com/watch?v=(videoId)
-	if url.query and url.query.v then
+	if url.query and url.query.v and string.len(url.query.v) > 0 then
 		info.Data = url.query.v
 
 	-- http://www.youtube.com/v/(videoId)


### PR DESCRIPTION
Typing http://www.youtube.com/watch?v= in chat can crash all the theatre screens which can't be fixed without a map change.
Added fix for this bug.
