### PR TITLE
Fixed the HTMLControls Back/Forward/Refresh buttons (correctly)

### DIFF
--- a/cinema/gamemode/modules/scoreboard/controls/cl_html.lua
+++ b/cinema/gamemode/modules/scoreboard/controls/cl_html.lua
@@ -329,18 +329,6 @@ function PANEL:AddFunction( obj, funcname, func )
 
 end
 
-function PANEL:HTMLBack()
-	if self.CurrentPage <= 1 then return end
-	self.CurrentPage = self.CurrentPage - 1
-	self:OpenURL( self.History[ self.CurrentPage ], true )
-end
-
-function PANEL:HTMLForward()
-	if self.CurrentPage == #self.History then return end
-	self.CurrentPage = self.CurrentPage + 1
-	self:OpenURL( self.History[ self.CurrentPage ], true )
-end
-
 function PANEL:OpeningURL( url )
 	
 end

--- a/cinema/gamemode/modules/scoreboard/controls/cl_htmlcontrols.lua
+++ b/cinema/gamemode/modules/scoreboard/controls/cl_htmlcontrols.lua
@@ -170,7 +170,7 @@ function PANEL:UpdateHistory( url )
 	if !table.HasValue(self.History, url) then -- It spams the same entry multiple times...
 		self.Cur = table.insert( self.History, url )
 	end
-	PrintTable(self.History)
+
 	self:UpdateNavButtonStatus()
 
 end

--- a/cinema/gamemode/modules/scoreboard/controls/cl_htmlcontrols.lua
+++ b/cinema/gamemode/modules/scoreboard/controls/cl_htmlcontrols.lua
@@ -3,7 +3,7 @@
 | |_ / _` |/ __/ _ \ '_ \| | | | '_ \ / __| '_ \ 
 |  _| (_| | (_|  __/ |_) | |_| | | | | (__| | | |
 |_|  \__,_|\___\___| .__/ \__,_|_| |_|\___|_| |_|
-                   |_| 2010 --]]
+                   |_| 2010 | Updated: 2015 --]]
 
 local PANEL = {}
 
@@ -23,8 +23,8 @@ function PANEL:Init()
 	self.BackButton:DockMargin( Spacing*3, Margins, Spacing, Margins )
 	self.BackButton.DoClick = function()
 		self.BackButton:SetDisabled( true )
-		self.HTML:HTMLBack()
 		self.Cur = self.Cur - 1
+		self.HTML:OpenURL(self.History[self.Cur])
 		self.Navigating = true
 	end
 	
@@ -35,8 +35,8 @@ function PANEL:Init()
 	self.ForwardButton:DockMargin( Spacing, Margins, Spacing, Margins )
 	self.ForwardButton.DoClick = function()
 		self.ForwardButton:SetDisabled( true )
-		self.HTML:HTMLForward()
 		self.Cur = self.Cur + 1
+		self.HTML:OpenURL(self.History[self.Cur])
 		self.Navigating = true
 	end
 	
@@ -48,7 +48,7 @@ function PANEL:Init()
 	self.RefreshButton.DoClick = function()
 		self.RefreshButton:SetDisabled( true )
 		self.Refreshing = true
-		self.HTML:Refresh()
+		self.HTML:OpenURL( self.HTML:GetURL() )
 	end
 	
 	self.HomeButton = vgui.Create( "DImageButton", self )
@@ -59,6 +59,7 @@ function PANEL:Init()
 	self.HomeButton.DoClick = function()
 		self.HTML:Stop()
 		self.HTML:OpenURL( self.HomeURL )
+		self.Cur = 1
 	end
 	
 	self.AddressBar = vgui.Create( "DTextEntry", self )
@@ -166,8 +167,10 @@ function PANEL:UpdateHistory( url )
 	
 	end
 	
-	self.Cur = table.insert( self.History, url )
-	
+	if !table.HasValue(self.History, url) then -- It spams the same entry multiple times...
+		self.Cur = table.insert( self.History, url )
+	end
+	PrintTable(self.History)
 	self:UpdateNavButtonStatus()
 
 end


### PR DESCRIPTION
`HTMLBack()` and `HTMLForward()` rarely work correctly due to them going "back" on the same URL as the current one. This is fixed by the `table.HasValue()` check and using `OpenURL()` based on the tracked history within `cl_htmlcontrols.lua`, thus removing the need for them. `Refresh()` still does not work so I simply used `OpenURL()` on the link from `GetURL()`, however `Stop()` apparently still works once the duplicate entry issue with the History is fixed.

Please remove the other Pull Request attempting the same goal as it contains out of date code.