### PR TITLE
Legs model copies bodygroups from playermodel

### DIFF
--- a/cinema/gamemode/modules/legs/cl_init.lua
+++ b/cinema/gamemode/modules/legs/cl_init.lua
@@ -199,6 +199,9 @@ function Legs:Think( maxseqgroundspeed )
 		
 		self.LegEnt:SetMaterial( LocalPlayer():GetMaterial() )
 		self.LegEnt:SetSkin( LocalPlayer():GetSkin() )
+		for _, group in pairs(LocalPlayer():GetBodyGroups()) do
+      self.LegEnt:SetBodygroup(group["id"], LocalPlayer():GetBodygroup(group["id"]))
+		end
 
 		self.Velocity = LocalPlayer():GetVelocity():Length2D()
 		

--- a/cinema/gamemode/modules/legs/cl_init.lua
+++ b/cinema/gamemode/modules/legs/cl_init.lua
@@ -200,7 +200,7 @@ function Legs:Think( maxseqgroundspeed )
 		self.LegEnt:SetMaterial( LocalPlayer():GetMaterial() )
 		self.LegEnt:SetSkin( LocalPlayer():GetSkin() )
 		for _, group in pairs(LocalPlayer():GetBodyGroups()) do
-      self.LegEnt:SetBodygroup(group["id"], LocalPlayer():GetBodygroup(group["id"]))
+			self.LegEnt:SetBodygroup(group["id"], LocalPlayer():GetBodygroup(group["id"]))
 		end
 
 		self.Velocity = LocalPlayer():GetVelocity():Length2D()


### PR DESCRIPTION
Noticed that the leg model doesn't have the same bodygroups as the playermodel.

I added the code where the skin and material is set, but maybe this (and the SetSkin/SetMaterial) should only bet set whenever the model changes?