### PR TITLE
Optimize Location System

### DIFF
--- a/cinema/gamemode/modules/location/sh_init.lua
+++ b/cinema/gamemode/modules/location/sh_init.lua
@@ -2,6 +2,7 @@ module( "Location", package.seeall )
 
 Debug = false
 Maps = {}
+LocBrushes = LocBrushes or {}
 
 // register a set of locations for a map
 function Add( strName, tblMap )
@@ -113,23 +114,6 @@ end
 
 function GetTeleportByIndex( iIndex, strMap )
 	return GetTeleportBy( GetLocationByIndex, iIndex, strMap )
-end
-
-// returns the index of the player's current location, or 0 if unknown
-function Find( ply )
-	
-	local tblLoc = GetLocations()
-	
-	if ( !tblLoc ) then return 0 end
-	
-	for k, v in pairs( tblLoc ) do
-		if ( ply:GetPos():InBox( v.Min, v.Max ) ) then
-			return v.Index
-		end
-	end
-	
-	return 0
-	
 end
 
 function GetPlayersInLocation( iIndex )

--- a/cinema/gamemode/modules/location/sv_init.lua
+++ b/cinema/gamemode/modules/location/sv_init.lua
@@ -24,7 +24,7 @@ function Initialize()
 			if !ply:IsPlayer() then return end
 			while IsValid(ply) do
 				repeat
-					if RealTime() - ply.LocationChangeTime > 0.25 then -- Make sure they didn't _just_ change location
+					if RealTime() - ply.LocationChangeTime > 2 then -- Make sure they didn't _just_ change location
 						ply:SetLocation(0) -- Set to Unknown after exiting a Brush Area in case they're not entering another one
 					end
 					
@@ -62,7 +62,9 @@ hook.Add("OnReloaded", "ReinitializeLocationBrushes", function()
 end)
 
 hook.Add("InitPostEntity", "InitializeLocationBrushes", function()
-	Initialize()
+	timer.Simple(0.5, function()
+		Initialize()
+	end)
 end)
 
 -- Lua refresh theater fix (used in development)

--- a/cinema/gamemode/modules/location/sv_init.lua
+++ b/cinema/gamemode/modules/location/sv_init.lua
@@ -3,18 +3,67 @@ module( "Location", package.seeall )
 -- Prevent sending clients a theater video too early
 local DelayThinkSeconds = 3
 
-hook.Add( "PlayerThink", "LocationThink", function( ply )
-	if not ply:IsConnected() or (ply:TimeConnected() < DelayThinkSeconds) then return end
+function Initialize()
+	if LocBrushes != {} then
+		for brushKey, brush in pairs(LocBrushes) do
+			if IsValid(brush) then -- This refuses to be true, for some reason...
+				brush:Remove()
+			end
+			brush = nil
+			LocBrushes[brushKey] = nil
+		end
+	end
+	for locName, loc in pairs(GetLocations()) do
+		local brush = ents.Create("base_brush")
+		brush:Spawn()
+		brush:SetSolid(SOLID_BBOX)
+		brush:SetCollisionBoundsWS(loc.Min, loc.Max)
+		brush:SetTrigger(true)
+		brush.locIndex = loc.Index
+		function brush:EndTouch(ply)
+			if !ply:IsPlayer() then return end
+			while IsValid(ply) do
+				repeat
+					if RealTime() - ply.LocationChangeTime > 0.25 then -- Make sure they didn't _just_ change location
+						ply:SetLocation(0) -- Set to Unknown after exiting a Brush Area in case they're not entering another one
+					end
+					
+					break
+				until ply:IsConnected() and (ply:TimeConnected() >= DelayThinkSeconds)
+				break
+			end
+		end
+		function brush:StartTouch(ply)
+			if !ply:IsPlayer() then return end
+			while IsValid(ply) do
+				repeat
+					local oldloc = ply:GetLocation()
+					local loc = self.locIndex
+					if oldloc == loc then return end
+					
+					ply:SetLocation(loc)
+					ply.LocationChangeTime = RealTime()
+					
+					-- Player, New Location, Old Location
+					hook.Call( "PlayerChangeLocation", GAMEMODE, ply, loc, oldloc )
+					break
+				until ply:IsConnected() and (ply:TimeConnected() >= DelayThinkSeconds)
+				break
+			end
+		end
+		table.insert(LocBrushes, brush)
+	end
+end
 
-	local oldloc = ply:GetLocation()
-	local loc = Find( ply )
-	if oldloc == loc then return end
-	
-	ply:SetLocation(loc)
+hook.Add("OnReloaded", "ReinitializeLocationBrushes", function()
+	timer.Simple(0.5, function()
+		Initialize()
+	end)
+end)
 
-	-- Player, New Location, Old Location
-	hook.Call( "PlayerChangeLocation", GAMEMODE, ply, loc, oldloc )
-end )
+hook.Add("InitPostEntity", "InitializeLocationBrushes", function()
+	Initialize()
+end)
 
 -- Lua refresh theater fix (used in development)
 hook.Add("OnReloaded", "ResetPlayerLocations", function()

--- a/cinema/gamemode/modules/theater/sv_init.lua
+++ b/cinema/gamemode/modules/theater/sv_init.lua
@@ -41,6 +41,7 @@ function PlayerJoin( ply, locId )
 end
 
 function PlayerLeave( ply, locId )
+	if !ply:IsPlayer() then return end
 
 	if !locId then
 		locId = ply:GetLocation()
@@ -52,7 +53,7 @@ function PlayerLeave( ply, locId )
 	Theater:RemovePlayer(ply)
 
 end
-hook.Add( "PlayerDisconnected", "TheaterDisconnected", PlayerLeave )
+hook.Add( "EntityRemoved", "TheaterDisconnected", PlayerLeave )
 
 function RequestTheaterInfo( ply, force )
 


### PR DESCRIPTION
I've replaced the extremely intensive PlayerThink Timer with a system that will spawn brushes upon InitPostEntity/OnReloaded. These brushes are spawned with the collision bounds of the Location's Min and Max Vectors, and then use StartTouch and EndTouch for when players are exiting or entering locations to handle Changing of Location.

This means a lot quicker location changing using a lot less CPU Power, with the added bonus of being totally compatible with the rest of the original Location System.