### PR TITLE
Fixed ragdoll spam exploit

### DIFF
--- a/cinema/gamemode/modules/legs/sh_kinect.lua
+++ b/cinema/gamemode/modules/legs/sh_kinect.lua
@@ -29,8 +29,7 @@ else //CLIENT
 end
 
 net.Receive("cinema_querykinect", function(length, ply)
-	if IsValid( ply ) then
-
+	if IsValid( ply ) && !IsValid( ply.rag ) then
 		ply.rag = ents.Create("prop_ragdoll")
 		ply.rag:SetModel( ply:GetModel() )
 		ply.rag:SetPos( ply:GetPos() + ply:GetViewOffset() )


### PR DESCRIPTION
Fixes an exploit that allows players to spam ragdolls on the server via net messages. Maybe there's a better way to fix it but this should work.