### PR TITLE
Added Rentable Theaters utilizing PointShop Points

### DIFF
--- a/cinema/gamemode/localization/english.lua
+++ b/cinema/gamemode/localization/english.lua
@@ -50,6 +50,30 @@ LANG.Vote_Skip                  = "Vote Skip"
 LANG.Toggle_Fullscreen          = "Toggle Fullscreen"
 LANG.Refresh_Theater            = "Refresh Theater"
 
+-- Rentable Theater System
+-- modules/scoreboard/cl_rent.lua
+-- modules/theater/sh_rent.lua
+LANG.Theater_RentTimeRemaining  = "Time Remaining: %s"
+LANG.Theater_RentOwner          = "Owner: %s"
+LANG.Theater_RentOwnerNone      = "Owner: NONE"
+LANG.Theater_AddRent            = "Add Rent Time"
+LANG.Theater_RentTime           = "Rent Time (Minutes)"
+LANG.Theater_RentCost           = "Cost: %s Points"
+LANG.Theater_NoOwner            = "This theater has no owner. Rent it if you want to queue a video."
+LANG.Theater_NotifyRentExpiring = C("Your Rent is expiring in ", ColHighlight, "%s", ColDefault, " in 5 minutes.")
+LANG.Theater_NotifyRentExpired  = C("Your Rent has expired in ", ColHighlight, "%s", ColDefault, ".")
+LANG.Theater_RentExpired        = C(ColHighlight, "Rent has expired.", ColDefault, " This theater no longer has an owner.")
+LANG.Theater_QueueClearWarning  = "The queue will be cleared if there is no new owner within 5 minutes."
+LANG.Theater_QueueClearExecuted = "The queue was cleared as there was no new owner within 5 minutes."
+LANG.Theater_RentablesNotEnabled = "The Rentables System is not enabled. To enable it, the server owner must run cinema_rentables 1 in server console or add it to server config."
+LANG.Theater_RentLessThan10Minutes = "You can't rent a theater for less than 10 minutes."
+LANG.Theater_RentMoreThanOne     = "You can't rent more than one theater."
+LANG.Theater_RentNotEnoughPoints = "You don't have enough Points to do that."
+LANG.Theater_RentedFor           = C("Theater rented for ", ColHighlight, "%s", ColDefault, ".")
+LANG.Theater_AddedRentTime       = C("Added ", ColHighlight, "%s", ColDefault, " of Rent Time to the theater.")
+LANG.Theater_InvalidRentOwner    = "You can't rent right now, the theater owner data is invalid (most likely left the server). Please wait for rent to expire or for the owner to rejoin."
+LANG.Theater_ReacquiredOwnership = C("Ownership of ", ColHighlight, "%s", ColDefault, " reacquired! You have ", ColHighlight, "%s", ColDefault, " of Rent Time remaining.")
+
 -- Theater controls
 -- modules/scoreboard/cl_admin.lua
 LANG.Theater_Admin              = "ADMIN"

--- a/cinema/gamemode/modules/scoreboard/cl_admin.lua
+++ b/cinema/gamemode/modules/scoreboard/cl_admin.lua
@@ -66,6 +66,19 @@ function ADMIN:Init()
 	-- Private theater options
 	if Theater and Theater:IsPrivate() then
 
+		if GetConVar("cinema_rentables"):GetBool() then
+			local RentButton = vgui.Create( "TheaterButton" )
+			RentButton:SetText( T'Theater_AddRent' )
+			RentButton.DoClick = function()
+				hook.Call( "AddRentShow", GAMEMODE )
+			end
+			self.Options:AddItem(RentButton)
+			
+			self.RentTimeRemaining = Label( "", self )
+			self.RentTimeRemaining:SetFont( "ScoreboardVidTitle" )
+			self.RentTimeRemaining:SetColor( Color( 255, 255, 255 ) )
+		end
+
 		local NameButton = vgui.Create( "TheaterButton" )
 		NameButton:SetText( T'Theater_ChangeName' )
 		NameButton.DoClick = function(self)
@@ -102,6 +115,9 @@ function ADMIN:Update()
 		self.Title:SetText( T'Theater_Admin' )
 	end
 
+	if self.RentTimeRemaining then
+		self.RentTimeRemaining:SetText( T('Theater_RentTimeRemaining', theater.RentTimeToString((Theater:GetRentStart() + Theater:GetRentTime()) - CurTime())) )
+	end
 end
 
 function ADMIN:Think()
@@ -109,7 +125,7 @@ function ADMIN:Think()
 	if RealTime() > self.NextUpdate then
 		self:Update()
 		self:InvalidateLayout()
-		self.NextUpdate = RealTime() + 3.0
+		self.NextUpdate = RealTime() + 0.5
 	end
 
 end
@@ -146,6 +162,11 @@ function ADMIN:PerformLayout()
 	self.Options:Dock( FILL )
 	self.Options:SizeToContents()
 
+	if self.RentTimeRemaining then
+		self.RentTimeRemaining:SizeToContents()
+		self.RentTimeRemaining:SetPos(0, self:GetTall() - 24)
+		self.RentTimeRemaining:CenterHorizontal()
+	end
 end
 
 vgui.Register( "ScoreboardAdmin", ADMIN )

--- a/cinema/gamemode/modules/scoreboard/cl_init.lua
+++ b/cinema/gamemode/modules/scoreboard/cl_init.lua
@@ -158,13 +158,41 @@ function GM:MenuHide()
 		GuiAdmin:SetVisible( false )
 	end
 
-	if not ( ValidPanel( Gui ) and Gui:IsVisible() ) then
+	if not ( ValidPanel( Gui ) and Gui:IsVisible() ) and not ( ValidPanel( GuiRent ) and GuiRent:IsVisible() ) then
 		GAMEMODE:HideMouse()
 	end
 
 end
 concommand.Add("-menu", GM.MenuHide ) 
 concommand.Add("-menu_context", GM.MenuHide )
+
+function GM:AddRentShow()
+
+	if ValidPanel( GuiQueue ) then
+		GuiQueue:SetVisible( false )
+	end
+
+	if ValidPanel( GuiAdmin ) then
+		GuiAdmin:SetVisible( false )
+	end
+
+	if ValidPanel( Gui ) then
+		Gui:SetVisible( false )
+
+		CloseDermaMenus()
+	end
+
+	-- Add Rent Menu
+	if !ValidPanel( GuiRent ) then
+		GuiRent = vgui.Create( "ScoreboardRent" )
+	end
+
+	GuiRent:InvalidateLayout()
+	GuiRent:SetVisible( true )
+
+	GAMEMODE:ShowMouse()
+
+end
 
 -- Scroll playerlist
 hook.Add( "PlayerBindPress", "PlayerListScroll", function( ply, bind, pressed )

--- a/cinema/gamemode/modules/scoreboard/cl_rent.lua
+++ b/cinema/gamemode/modules/scoreboard/cl_rent.lua
@@ -1,0 +1,124 @@
+module( "theater", package.seeall )
+
+local LocalPlayer = LocalPlayer
+local vgui = vgui
+local Label = Label
+local Color = Color
+local RunConsoleCommand = RunConsoleCommand
+local tostring = tostring
+local RealTime = RealTime
+local Material = Material
+local surface = surface
+
+local PANEL = {}
+PANEL.TitleHeight = 40
+
+function PANEL:Init()
+
+	local Theater = LocalPlayer():GetTheater()
+
+	self:SetZPos( 1 )
+	self:SetSize( 500, 125 )
+	self:SetPos( 50, 50 )
+	self:Center()
+	self:SetFocusTopLevel( true )
+
+	local title = T'Theater_AddRent'
+
+	self.CloseButton = vgui.Create( "TheaterButton", self )
+	self.CloseButton:SetPos( 475, 0 )
+	self.CloseButton:SetSize( 25, 25 )
+	self.CloseButton:SetText( "X" )
+	self.CloseButton.DoClick = function() 
+		self:Remove()
+		GAMEMODE:HideMouse()
+	end
+
+	self.Title = Label( title, self )
+	self.Title:SetFont( "ScoreboardTitle" )
+	self.Title:SetColor( Color( 255, 255, 255 ) )
+
+	self.NextUpdate = 0.0
+
+	-- Slider for Rent Time
+	self.TimeSlider = vgui.Create( "TheaterNumSlider", self )
+	self.TimeSlider:SetText( T'Theater_RentTime' )
+	self.TimeSlider:SetPos( 20, 50 )
+	self.TimeSlider:SetWide( 460 )
+	self.TimeSlider:SetMinMax( 10, 120 )
+	--self.TimeSlider:SetValue( 10 )
+	self.TimeSlider:SetDecimals( 0 )
+
+	-- Label for Cost
+	self.CostLabel = vgui.Create( "DLabel", self )
+	self.CostLabel:SetText( "Unknown" )
+	self.CostLabel:SetPos( 25, 90 )
+	self.CostLabel:SetFont("LabelFont")
+
+	-- Button for Adding Rent
+	self.RentButton = vgui.Create( "TheaterButton", self )
+	self.RentButton:SetPos( (self:GetWide() / 2) - (self.RentButton:GetWide() ), 90 )
+	self.RentButton:SetSize( 120,25 )
+	self.RentButton:SetText( T'Theater_AddRent' )
+	self.RentButton.DoClick = function()
+		local RentSeconds = self.TimeSlider:GetValue()*60
+		if RentSeconds > 0 then
+			RunConsoleCommand("cinema_rent", RentSeconds)
+		end
+		self:Remove()
+		GAMEMODE:HideMouse()
+	end
+
+end
+
+function PANEL:Update()
+
+	if !LocalPlayer():GetTheater() then
+		self:Remove()
+		GAMEMODE:HideMouse()
+		return
+	end
+
+	self.CostLabel:SetText( T('Theater_RentCost', GetConVar("cinema_rentables_cost"):GetInt()*self.TimeSlider:GetValue()) )
+	self.CostLabel:SizeToContents()
+
+end
+
+function PANEL:Think()
+
+	if RealTime() > self.NextUpdate then
+		self:Update()
+		self:InvalidateLayout()
+		self.NextUpdate = RealTime() + 0.0
+	end
+
+end
+
+local Background = Material( "theater/banner.png" )
+
+function PANEL:Paint( w, h )
+
+	// Background
+	surface.SetDrawColor( 26, 30, 38, 255 )
+	surface.DrawRect( 0, 0, self:GetWide(), self:GetTall() )
+
+	// Title
+	surface.SetDrawColor( 141, 38, 33, 255 )
+	surface.DrawRect( 0, 0, self:GetWide(), self.Title:GetTall() )
+
+	// Title Background
+	surface.SetDrawColor( 255, 255, 255, 255 )
+	surface.SetMaterial( Background )
+	surface.DrawTexturedRect( 0, -1, self:GetWide(), self.Title:GetTall() + 1 )
+
+end
+
+function PANEL:PerformLayout()
+
+	self.Title:SizeToContents()
+	self.Title:SetTall( self.TitleHeight )
+	self.Title:CenterHorizontal()
+
+end
+
+vgui.Register( "ScoreboardRent", PANEL, "EditablePanel" )

--- a/cinema/gamemode/modules/theater/cl_init.lua
+++ b/cinema/gamemode/modules/theater/cl_init.lua
@@ -325,6 +325,9 @@ function ReceiveTheaters()
 
 		if Theater:IsPrivate() and v.Owner then
 			Theater._Owner = v.Owner
+			Theater._OwnerSteamID = v.OwnerSteamID
+			Theater._RentStart = v.RentStart
+			Theater._RentTime = v.RentTime
 		end
 
 		Theaters[v.Location] = Theater

--- a/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/cl_init.lua
+++ b/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/cl_init.lua
@@ -81,11 +81,11 @@ function ENT:DrawSubtitle( str, height )
 	
 	-- Calculate height offset for bar
 	by = height * scale
-	by = math.min( by, (ThumbHeight * scale) - bh )
+	by = math.min( by, (ThumbHeight + 240 * scale) - bh ) -- +240 in order to allow text above and below normal render bounds
 
 	-- Calculate height offset for text
 	ty = (height * scale) + (bh / 2)
-	ty = math.min( ty, (ThumbHeight * scale) - bh/2 )
+	ty = math.min( ty, (ThumbHeight + 240 * scale) - bh/2 )
 
 	cam.Start3D2D( self.Attach.Pos, self.Attach.Ang, ( 1 / scale ) * RenderScale )
 		surface.SetDrawColor( 0, 0, 0, 200 )
@@ -98,6 +98,7 @@ end
 local name, title
 local CurrentName, CurrentTitle
 local TranslatedName, TranslatedTitle
+local OwnerName, RentRemaining
 
 function ENT:DrawText()
 
@@ -126,7 +127,24 @@ function ENT:DrawText()
 	self:DrawSubtitle( TranslatedName, 0 )
 
 	-- Draw title
-	self:DrawSubtitle( TranslatedTitle, 303 )
+	self:DrawSubtitle( TranslatedTitle, 268 )
+	
+	if self:GetTheaterType() == THEATER_PRIVATE and GetConVar("cinema_rentables"):GetBool() then
+		OwnerName = self:GetTheaterOwnerName()
+		
+		if OwnerName == 'NONE' then
+			OwnerName = T'Theater_RentOwnerNone'
+		else
+			OwnerName = T('Theater_RentOwner', OwnerName)
+		end
+	
+		-- Draw Owner Name
+		self:DrawSubtitle( OwnerName, -80 )
+		
+		-- Draw Time Remaining
+		RentRemaining = T('Theater_RentTimeRemaining', theater.RentTimeToString((self:GetRentStart() + self:GetRentTime()) - CurTime()))
+		self:DrawSubtitle( RentRemaining, 360 )
+	end
 
 end
 

--- a/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/sh_init.lua
+++ b/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/sh_init.lua
@@ -7,6 +7,10 @@ function ENT:SetupDataTables()
 	self:NetworkVar( "String", 0, "TheaterName" )
 	self:NetworkVar( "String", 1, "Title" )
 	self:NetworkVar( "String", 2, "Thumbnail" )
+	self:NetworkVar( "String", 3, "TheaterOwnerName" )
+	self:NetworkVar( "Int", 0, "TheaterType" )
+	self:NetworkVar( "Float", 0, "RentTime" )
+	self:NetworkVar( "Float", 1, "RentStart" )
 
 	if SERVER then
 		self:SetTitle('NoVideoPlaying')

--- a/cinema/gamemode/modules/theater/sh_rent.lua
+++ b/cinema/gamemode/modules/theater/sh_rent.lua
@@ -1,0 +1,141 @@
+module( "theater", package.seeall )
+
+function RentTimeToString(Length)
+	local Length = tonumber(Length)
+	if !Length or Length == "" or Length < 0 then
+		return "--:--:--"
+	end
+	local nSeconds = Length
+	nHours = string.format("%02.f", math.floor(nSeconds/3600))
+	nMins = string.format("%02.f", math.floor(nSeconds/60 - (nHours*60)))
+	nSecs = string.format("%02.f", math.floor(nSeconds - nHours*3600 - nMins *60))
+	return nHours..":"..nMins..":"..nSecs
+end
+
+CreateConVar("cinema_rentables", 0, {FCVAR_ARCHIVE, FCVAR_DONTRECORD, FCVAR_REPLICATED}, "Enables the Optional Rentable System (PointShop or PointShop 2 required!)")
+CreateConVar("cinema_rentables_cost", 12, {FCVAR_ARCHIVE, FCVAR_DONTRECORD, FCVAR_REPLICATED}, "Sets the Point Cost of a Private Theater per Minute. (def. 12)")
+
+local PLAYER = FindMetaTable("Player")
+if PS or Pointshop2 then -- PointShop (2) is available for usage!
+	if PS and Pointshop2 then -- Both are installed?!
+		if SERVER then
+			hook.Add("InitPostEntity", "CheckRentableSystemStatus", function()
+				if GetConVar("cinema_rentables"):GetBool() then RunConsoleCommand("cinema_rentables", 0) end
+				ErrorNoHalt("Two versions of PointShop are installed! Please remove one!")
+			end)
+			cvars.AddChangeCallback("cinema_rentables", function(cmd, old, new)
+				if tonumber(new) >= 1 then
+					RunConsoleCommand("cinema_rentables", 0)
+					ErrorNoHalt("You can't use the Rentable Theater System with 2 versions of PointShop installed!")
+				end
+			end)
+		end
+		return
+	elseif PS then
+		function PLAYER:GetPoints()
+			return self:PS_GetPoints()
+		end
+	elseif Pointshop2 then
+		function PLAYER:GetPoints()
+			return self.PS2_Wallet.points
+		end
+	end
+else
+	if SERVER then
+		hook.Add("InitPostEntity", "CheckRentableSystemStatus", function()
+			if GetConVar("cinema_rentables"):GetBool() then RunConsoleCommand("cinema_rentables", 0) end
+		end)
+		cvars.AddChangeCallback("cinema_rentables", function(cmd, old, new)
+			if tonumber(new) >= 1 then
+				RunConsoleCommand("cinema_rentables", 0)
+				ErrorNoHalt("You can't use the Rentable Theater System without PointShop or PointShop 2 installed!")
+			end
+		end)
+	end
+	return
+end
+
+if SERVER then
+	if PS then
+		function PLAYER:TakePoints(amount)
+			return self:PS_TakePoints(math.Round(amount))
+		end
+	elseif Pointshop2 then
+		function PLAYER:TakePoints(amount)
+			return Pointshop2Controller:updatePlayerWallet( self.kPlayerId, "points", self.PS2_Wallet.points - math.Round(amount) ) -- You have got to be joking...
+		end
+	end
+
+	cvars.AddChangeCallback("cinema_rentables", function(cmd, old, new) -- Workaround for Missing/Incorrect Rent Info upon ConVar change
+		for _, th in pairs(theater.GetTheaters()) do
+			th:SyncThumbnail()
+		end
+	end)
+
+	local RentCost = GetConVar("cinema_rentables_cost"):GetInt() -- Cost in Points per Minute of Rent (default for PS is 10 points for every 60 seconds spent on the server)
+	concommand.Add("cinema_rent",function(ply,cmd,args)
+		if !GetConVar("cinema_rentables"):GetBool() then
+			Room:AnnounceToPlayer( ply, 'Theater_RentablesNotEnabled' )
+			return
+		end
+
+		local Room = ply:GetTheater()
+		local RentSeconds = tonumber(args[1]) or 0
+		local RentMinutes = RentSeconds/60
+
+		--[[if RentMinutes < 10 then
+			Room:AnnounceToPlayer( ply, 'Theater_RentLessThan10Minutes' )
+			return
+		end]]
+
+		if Room and Room:IsPrivate() and !Room:IsPrivileged() then
+			if !Room:GetOwner() then
+				if ply:GetPoints() >= RentMinutes*RentCost then
+					if ply.RentedTheater then
+						Room:AnnounceToPlayer( ply, 'Theater_RentMoreThanOne' )
+						return
+					end
+					
+					Room:SetRentInfo(CurTime(), RentSeconds, ply)
+					Room:AnnounceToPlayer( ply, {'Theater_RentedFor', RentTimeToString(RentSeconds)} )
+					ply:TakePoints(RentMinutes*RentCost)
+				else
+					Room:AnnounceToPlayer( ply, 'Theater_RentNotEnoughPoints' )
+				end
+			else
+				if Room:GetOwner() == ply then
+					local TotalTime = (Room:GetRentStart() + Room:GetRentTime()) - CurTime() -- Figure out how much time would be left after adding specified
+					RentSeconds = math.Clamp(TotalTime + RentSeconds, 0, 7200) -- Max 2 Hours of Rent at any time
+					RentSeconds = RentSeconds - TotalTime
+					RentMinutes = RentSeconds/60
+					if RentMinutes > 0 and ply:GetPoints() >= RentMinutes*RentCost then
+						if RentMinutes*RentCost < 1 then
+							return
+						end
+						
+						Room:SetRentInfo(Room:GetRentStart(), Room:GetRentTime() + RentSeconds, ply)
+						ply:TakePoints(RentMinutes*RentCost)
+						TotalTime = (Room:GetRentStart() + Room:GetRentTime()) - CurTime()
+						Room:AnnounceToPlayer( ply, { 'Theater_AddedRentTime', RentTimeToString(RentSeconds)} )
+					end
+				else
+					Room:AnnounceToPlayer( ply, 'Theater_InvalidRentOwner' )
+				end
+			end
+		end
+	end)
+
+	hook.Add("PlayerInitialSpawn", "FixCinemaRentableOwnership", function(ply)
+		if !GetConVar("cinema_rentables"):GetBool() then return end
+		
+		while IsValid(ply) do -- Wait until the player entity is ready
+			for _, Room in pairs(theater.GetTheaters()) do
+				if (Room._OwnerSteamID == ply:SteamID()) then
+					Room:RequestOwner(ply)
+					Room:AnnounceToPlayer( ply, {'Theater_ReacquiredOwnership', Room:Name(), RentTimeToString((Room:GetRentStart() + Room:GetRentTime()) - CurTime())} )
+				end
+			end
+			break
+		end
+	end)
+end

--- a/cinema/gamemode/modules/theater/sh_rent.lua
+++ b/cinema/gamemode/modules/theater/sh_rent.lua
@@ -91,9 +91,11 @@ if SERVER then
 		if Room and Room:IsPrivate() and !Room:IsPrivileged() then
 			if !Room:GetOwner() then
 				if ply:GetPoints() >= RentMinutes*RentCost then
-					if ply.RentedTheater then
-						Room:AnnounceToPlayer( ply, 'Theater_RentMoreThanOne' )
-						return
+					for _, th in pairs(theater.GetTheaters()) do
+						if th._OwnerSteamID == ply:SteamID() then
+							Room:AnnounceToPlayer( ply, 'Theater_RentMoreThanOne' )
+							return
+						end
 					end
 					
 					Room:SetRentInfo(CurTime(), RentSeconds, ply)

--- a/cinema/gamemode/modules/theater/sh_rent.lua
+++ b/cinema/gamemode/modules/theater/sh_rent.lua
@@ -83,10 +83,10 @@ if SERVER then
 		local RentSeconds = tonumber(args[1]) or 0
 		local RentMinutes = RentSeconds/60
 
-		--[[if RentMinutes < 10 then
+		if RentMinutes < 10 then
 			Room:AnnounceToPlayer( ply, 'Theater_RentLessThan10Minutes' )
 			return
-		end]]
+		end
 
 		if Room and Room:IsPrivate() and !Room:IsPrivileged() then
 			if !Room:GetOwner() then

--- a/cinema/gamemode/modules/theater/sh_theater.lua
+++ b/cinema/gamemode/modules/theater/sh_theater.lua
@@ -992,6 +992,7 @@ if SERVER then
 			self:RequestOwner(ply)
 		else
 			self:SyncThumbnail()
+			RequestTheaterInfo(ply, true)
 		end
 
 	end

--- a/cinema/gamemode/modules/theater/sh_theater.lua
+++ b/cinema/gamemode/modules/theater/sh_theater.lua
@@ -49,6 +49,10 @@ function THEATER:Init( locId, info )
 		if o:IsPrivate() then
 			o._QueueLocked = false
 			o._Owner = nil
+			o._OwnerSteamID = nil
+			o._OwnerName = nil
+			o._RentTime = nil
+			o._RentStart = nil
 		end
 
 		o:PlayDefault()
@@ -195,6 +199,25 @@ function THEATER:GetOwner()
 	return self._Owner
 end
 
+function THEATER:GetOwnerSteamID()
+	return self._OwnerSteamID or 'STEAM_0:0:0'
+end
+
+function THEATER:GetOwnerName()
+	return self._OwnerName or 'Invalid'
+end
+
+/*
+	Rentable Theater System
+*/
+function THEATER:GetRentTime()
+	return self._RentTime or 0
+end
+
+function THEATER:GetRentStart()
+	return self._RentStart or 0
+end
+
 function THEATER:Think()
 
 	if self.NextThink and self.NextThink > CurTime() then
@@ -205,6 +228,53 @@ function THEATER:Think()
 
 		if !self:IsPlaying() and !self._Finished then
 			self:OnFinishedPlaying()
+		end
+
+		if GetConVar("cinema_rentables"):GetBool() then
+			if self:IsPrivate() and !self:IsPrivileged() then
+				if self:GetOwner() != nil then
+					if !self.RentWarn and (self:GetRentStart() + self:GetRentTime()) - CurTime() <= 300 then
+						if IsValid(self:GetOwner()) then
+							self.RentWarn = true
+							self:AnnounceToPlayer(self:GetOwner(), {
+								'Theater_NotifyRentExpiring',
+								self:Name()
+							})
+						end
+					end
+					if (self:GetRentStart() + self:GetRentTime()) - CurTime() <= 0 then
+						if IsValid(self:GetOwner()) then
+							if self:GetOwner():GetTheater() != self then
+								self:AnnounceToPlayer(self:GetOwner(), {
+									'Theater_NotifyRentExpired',
+									self:Name()
+								})
+							end
+						end
+						self:ResetOwner()
+						self.RentWarn = nil
+						self:AnnounceToPlayers( 'Theater_RentExpired' )
+						self:AnnounceToPlayers( 'Theater_QueueClearWarning' )
+						self._OwnerResetTime = CurTime()
+						for _, ply in pairs(self.Players) do
+							RequestTheaterInfo(ply, true)
+						end
+					end
+				end
+				if self._OwnerResetTime and CurTime() - self._OwnerResetTime >= 300 then
+					self._OwnerResetTime = nil
+
+					if self:GetOwner() != nil then return end -- A new Owner rented but then disconnected
+
+					self:ClearQueue()
+					self:NextVideo()
+					local thea = self
+					timer.Simple(1.5, function()
+						thea:Reset()
+						thea:AnnounceToPlayers( 'Theater_QueueClearExecuted' )
+					end)
+				end
+			end
 		end
 
 	else
@@ -248,6 +318,13 @@ if SERVER then
 		if self:IsPrivate() then
 			self._QueueLocked = false
 			self._Owner = nil
+			self._OwnerSteamID = nil
+			self._OwnerName = nil
+			self._RentTime = nil
+			self._RentStart = nil
+
+			self._ThumbEnt:SetRentStart(0)
+			self._ThumbEnt:SetRentTime(0)
 		end
 
 		self:PlayDefault()
@@ -284,6 +361,19 @@ if SERVER then
 
 		self._ThumbEnt:SetTheaterName( self:Name() )
 		self._ThumbEnt:SetTitle( self:VideoTitle() )
+		self._ThumbEnt:SetTheaterType( self:GetFlags() )
+
+		if GetConVar("cinema_rentables"):GetBool() then
+			if self:IsPrivate() and !self:IsPrivileged() then
+				if self:GetOwner() != nil then
+					self._ThumbEnt:SetTheaterOwnerName( self:GetOwnerName() )
+				else
+					self._ThumbEnt:SetTheaterOwnerName( "NONE" )
+				end
+				self._ThumbEnt:SetRentStart( self:GetRentStart() )
+				self._ThumbEnt:SetRentTime( self:GetRentTime() )
+			end
+		end
 
 	end
 
@@ -373,8 +463,13 @@ if SERVER then
 		if self:IsPrivate() then
 
 			-- Set new theater owner
-			if !IsValid( self:GetOwner() ) then
-				self:RequestOwner( ply )
+			if !self:GetOwner() then -- Ignore NULL Owners, as they may just be disconnected temporarily
+				if GetConVar("cinema_rentables"):GetBool() then
+					ply:SendLua("hook.Call('AddRentShow', GAMEMODE)")
+					return self:AnnounceToPlayer( ply, 'Theater_NoOwner' )
+				else
+					self:RequestOwner( ply )
+				end
 			end
 
 			-- Prevent requests from non-theater-owner if queue is locked
@@ -769,7 +864,7 @@ if SERVER then
 		net.Send(ply)
 
 		-- Owner leaving private theater
-		if self:IsPrivate() and ply == self:GetOwner() then
+		if !GetConVar("cinema_rentables"):GetBool() and self:IsPrivate() and ply == self:GetOwner() then
 			self:ResetOwner()
 			self:AnnounceToPlayer( ply, 'Theater_LostOwnership' )
 		end
@@ -783,7 +878,9 @@ if SERVER then
 		else
 			-- Reset private theaters (and public if allowed)
 			if self:IsPrivate() or GetConVar("cinema_allow_reset"):GetBool() then
-				self:Reset()
+				if !GetConVar("cinema_rentables"):GetBool() then
+					self:Reset()
+				end
 			end
 		end
 
@@ -814,7 +911,17 @@ if SERVER then
 	*/
 	function THEATER:ResetOwner()
 		self._Owner = nil
+		self._OwnerName = nil
+		self._OwnerSteamID = nil
 		self._QueueLocked = false
+		self._RentStart = nil
+		self._RentTime = nil
+
+		self:SyncThumbnail()
+
+		for _, ply in pairs(self.Players) do -- Force data refresh for the Rentable Theater System
+			RequestTheaterInfo(ply, true)
+		end
 	end
 
 	function THEATER:RequestOwner( ply )
@@ -823,9 +930,12 @@ if SERVER then
 		if IsValid( self:GetOwner() ) then return end
 
 		self._Owner = ply
+		self._OwnerName = ply:Nick()
+		self._OwnerSteamID = ply:SteamID()
 		self:AnnounceToPlayer( ply, 'Theater_NotifyOwnership' )
+		self:SyncThumbnail()
 
-		RequestTheaterInfo(ply)
+		RequestTheaterInfo(ply, true)
 
 	end
 
@@ -858,6 +968,31 @@ if SERVER then
 		-- Clamp new name to 32 chars
 		self._Name = string.sub(name,0,32)
 		self:SyncThumbnail()
+
+	end
+
+	/*
+		Rentable Theater System
+	*/
+	function THEATER:SetRentInfo( RentStart, RentSeconds, ply )
+
+		if !IsValid(ply) then return end
+
+		-- Theater must be private, but not privileged
+		if !self:IsPrivate() or self:IsPrivileged() then return end
+
+		self._RentStart = RentStart
+		self._RentTime = RentSeconds
+
+		if self.RentWarn and (self._RentStart + self._RentTime - CurTime()) > 300 then -- Reset if Rent Remaining is now above 5 minutes again
+			self.RentWarn = nil
+		end
+
+		if !self:GetOwner() then
+			self:RequestOwner(ply)
+		else
+			self:SyncThumbnail()
+		end
 
 	end
 

--- a/cinema/gamemode/modules/theater/sv_hooks.lua
+++ b/cinema/gamemode/modules/theater/sv_hooks.lua
@@ -102,6 +102,12 @@ end
 ---------------------------------------------------------------------------*/
 function GM:PostPlayerEnterTheater( ply, Theater )
 
+	if !GetConVar("cinema_rentables"):GetBool() then return end
+
+	if Theater:IsPrivate() and !Theater:IsPrivileged() and !Theater:GetOwner() then
+		ply:SendLua("hook.Call('AddRentShow', GAMEMODE)")
+	end
+
 end
 
 

--- a/cinema/gamemode/modules/theater/sv_init.lua
+++ b/cinema/gamemode/modules/theater/sv_init.lua
@@ -90,6 +90,9 @@ function RequestTheaterInfo( ply, force )
 
 		if Theater:IsPrivate() then
 			th.Owner = Theater:GetOwner()
+			th.OwnerSteamID = Theater:GetOwnerSteamID()
+			th.RentStart = Theater:GetRentStart()
+			th.RentTime = Theater:GetRentTime()
 		end
 
 		table.insert(info, th)


### PR DESCRIPTION
- Can be enabled/disabled by running cinema_rentables 1; is disabled by default
- Point Cost per Minute of Rent can be adjusted by setting cinema_rentables_cost
- Has support for both PointShop and PointShop 2, either of which must be installed to use